### PR TITLE
Feat implement basic crud+seach of contract

### DIFF
--- a/contact/contact-api/src/main/java/com/sheep/ezloan/contact/api/controller/ContractController.java
+++ b/contact/contact-api/src/main/java/com/sheep/ezloan/contact/api/controller/ContractController.java
@@ -1,0 +1,90 @@
+package com.sheep.ezloan.contact.api.controller;
+
+import com.sheep.ezloan.contact.api.controller.dto.ContractDto;
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.contact.domain.service.ContractService;
+import com.sheep.ezloan.support.error.CoreApiException;
+import com.sheep.ezloan.support.error.ErrorType;
+import com.sheep.ezloan.support.model.DomainPage;
+import com.sheep.ezloan.support.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("${api.prefix}/contracts")
+public class ContractController {
+
+    private final ContractService contractService;
+
+    @PostMapping
+    public ApiResponse<ContractDto.Response> createContract(@RequestBody ContractDto.Request contractDto) {
+        ContractResult contract = contractService.createContract(contractDto.getPostUuid(),
+                contractDto.getRequestUserId(), contractDto.getReceiveUserId());
+
+        return ApiResponse.success(ContractDto.Response.of(contract));
+    }
+
+    @GetMapping("/{contractUuid}")
+    public ApiResponse<ContractDto.Response> getContract(@PathVariable(value = "contractUuid") UUID contractUuid) {
+        ContractResult contract = contractService.getContract(contractUuid);
+
+        return ApiResponse.success(ContractDto.Response.of(contract));
+    }
+
+    @GetMapping
+    public ApiResponse<List<ContractDto.Response>> getAllContracts(@RequestParam("page") int page,
+            @RequestParam("size") int size, @RequestParam("sort") String sort) {
+        DomainPage<ContractResult> contracts = contractService.getAllContracts(page, size, sort);
+
+        return ApiResponse.success(ContractDto.Response.of(contracts));
+    }
+
+    @GetMapping("/search/{username}")
+    public ApiResponse<List<ContractDto.Response>> searchContracts(@PathVariable(value = "username") String username,
+            @RequestParam("page") int page, @RequestParam("size") int size, @RequestParam("sort") String sort) {
+        DomainPage<ContractResult> contracts = contractService.searchContracts(username, page, size, sort);
+
+        return ApiResponse.success(ContractDto.Response.of(contracts));
+    }
+
+    @PatchMapping("/accept/{contractUuid}")
+    public ApiResponse<ContractDto.Response> acceptContract(@PathVariable(value = "contractUuid") UUID contractUuid) {
+        ContractResult contract = contractService.acceptContract(contractUuid);
+
+        return ApiResponse.success(ContractDto.Response.of(contract));
+    }
+
+    @PatchMapping("/complete/{contractUuid}")
+    public ApiResponse<ContractDto.Response> completeContract(@RequestHeader("User-Id") Long userId,
+            @PathVariable(value = "contractUuid") UUID contractUuid) {
+        ContractResult contract = contractService.completeContract(contractUuid, userId);
+
+        if (contract == null)
+            throw new CoreApiException(ErrorType.FORBIDDEN, null);
+        return ApiResponse.success(ContractDto.Response.of(contract));
+    }
+
+    @PatchMapping("/cancel/{contractUuid}")
+    public ApiResponse<ContractDto.Response> cancelContract(@RequestHeader("User-Id") Long userId,
+            @PathVariable(value = "contractUuid") UUID contractUuid) {
+        ContractResult contract = contractService.cancelContract(contractUuid, userId);
+
+        if (contract == null)
+            throw new CoreApiException(ErrorType.FORBIDDEN, null);
+        return ApiResponse.success(ContractDto.Response.of(contract));
+    }
+
+    @DeleteMapping("/{contractUuid}")
+    public ApiResponse<ContractDto.DeleteResponse> deleteContract(
+            @PathVariable(value = "contractUuid") UUID contractUuid) {
+        ContractDto.DeleteResponse deletedContract = ContractDto.DeleteResponse
+            .of(contractService.deleteContract(contractUuid));
+
+        return ApiResponse.success(deletedContract);
+    }
+
+}

--- a/contact/contact-api/src/main/java/com/sheep/ezloan/contact/api/controller/dto/ContractDto.java
+++ b/contact/contact-api/src/main/java/com/sheep/ezloan/contact/api/controller/dto/ContractDto.java
@@ -1,0 +1,90 @@
+package com.sheep.ezloan.contact.api.controller.dto;
+
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.contact.domain.model.ContractStatus;
+import com.sheep.ezloan.support.model.DomainPage;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public interface ContractDto {
+
+    @Data
+    @Builder
+    class Request {
+
+        private final UUID postUuid;
+
+        private final Long requestUserId;
+
+        private final Long receiveUserId;
+
+    }
+
+    @Data
+    @Builder
+    class DeleteResponse {
+
+        private final UUID contractUuid;
+
+        public static ContractDto.DeleteResponse of(UUID contractUuid) {
+            return DeleteResponse.builder().contractUuid(contractUuid).build();
+        }
+
+    }
+
+    @Data
+    @Builder
+    class Response {
+
+        private final UUID contractUuid;
+
+        private final UUID postUuid;
+
+        private final Long requestUserId;
+
+        private final Long receiveUserId;
+
+        private final String requestUsername;
+
+        private final String receiveUsername;
+
+        private final boolean isAccepted;
+
+        private final boolean requesterIsCompleted;
+
+        private final boolean receiverIsCompleted;
+
+        private final boolean requesterIsCanceled;
+
+        private final boolean receiverIsCanceled;
+
+        private final ContractStatus status;
+
+        public static Response of(ContractResult contractResult) {
+            return Response.builder()
+                .contractUuid(contractResult.getContractUuid())
+                .postUuid(contractResult.getPostUuid())
+                .requestUserId(contractResult.getRequestUserId())
+                .receiveUserId(contractResult.getReceiveUserId())
+                .requestUsername(contractResult.getRequestUsername())
+                .receiveUsername(contractResult.getReceiveUsername())
+                .isAccepted(contractResult.isAccepted())
+                .requesterIsCompleted(contractResult.isRequesterIsCompleted())
+                .receiverIsCompleted(contractResult.isReceiverIsCompleted())
+                .requesterIsCanceled(contractResult.isRequesterIsCanceled())
+                .receiverIsCanceled(contractResult.isReceiverIsCanceled())
+                .status(contractResult.getStatus())
+                .build();
+        }
+
+        public static List<Response> of(DomainPage<ContractResult> contracts) {
+            return contracts.getData().stream().map(Response::of).collect(Collectors.toList());
+        }
+
+    }
+
+}

--- a/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/model/Contract.java
+++ b/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/model/Contract.java
@@ -1,0 +1,24 @@
+package com.sheep.ezloan.contact.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class Contract {
+
+    private UUID postUuid;
+
+    private Long requestUserId;
+
+    private Long receiveUserId;
+
+    private String requestUsername;
+
+    private String receiveUsername;
+
+}

--- a/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/model/ContractResult.java
+++ b/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/model/ContractResult.java
@@ -1,0 +1,38 @@
+package com.sheep.ezloan.contact.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ContractResult {
+
+    private UUID contractUuid;
+
+    private UUID postUuid;
+
+    private Long requestUserId;
+
+    private Long receiveUserId;
+
+    private String requestUsername;
+
+    private String receiveUsername;
+
+    private boolean isAccepted;
+
+    private boolean requesterIsCompleted;
+
+    private boolean receiverIsCompleted;
+
+    private boolean requesterIsCanceled;
+
+    private boolean receiverIsCanceled;
+
+    private ContractStatus status;
+
+}

--- a/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/model/ContractStatus.java
+++ b/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/model/ContractStatus.java
@@ -1,0 +1,22 @@
+package com.sheep.ezloan.contact.domain.model;
+
+public enum ContractStatus {
+
+    WAITING("waiting"), IN_PROGRESS("in_progress"), COMPLETED("completed"), CANCELED("canceled");
+
+    private final String status;
+
+    ContractStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String toString() {
+        return this.status;
+    }
+
+}

--- a/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/repository/ContractRepository.java
+++ b/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/repository/ContractRepository.java
@@ -1,0 +1,31 @@
+package com.sheep.ezloan.contact.domain.repository;
+
+import com.sheep.ezloan.contact.domain.model.Contract;
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.support.model.DomainPage;
+
+import java.util.UUID;
+
+public interface ContractRepository {
+
+    ContractResult save(Contract contract);
+
+    ContractResult findByUuid(UUID contractUuid);
+
+    DomainPage<ContractResult> findAll(String sortBy, int page, int size);
+
+    DomainPage<ContractResult> searchByUsername(String username, String sortBy, int page, int size);
+
+    ContractResult acceptContract(UUID contractUuid);
+
+    ContractResult requesterCompleteContract(UUID contractUuid);
+
+    ContractResult receiverCompleteContract(UUID contractUuid);
+
+    ContractResult requesterCancelContract(UUID contractUuid);
+
+    ContractResult receiverCancelContract(UUID contractUuid);
+
+    void delete(UUID contractUuid);
+
+}

--- a/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/service/ContractService.java
+++ b/contact/contact-domain/src/main/java/com/sheep/ezloan/contact/domain/service/ContractService.java
@@ -1,0 +1,86 @@
+package com.sheep.ezloan.contact.domain.service;
+
+import com.sheep.ezloan.contact.domain.model.Contract;
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.contact.domain.repository.ContractRepository;
+import com.sheep.ezloan.support.model.DomainPage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ContractService {
+
+    private final ContractRepository contractRepository;
+
+    @Transactional
+    public ContractResult createContract(UUID postUuid, Long requestUserId, Long receiveUserId) {
+
+        // 임시 유저네임 생성
+        String requestUsername = "temporaryUser1";
+        String receiveUsername = "temporaryUser2";
+
+        return contractRepository
+            .save(new Contract(postUuid, requestUserId, receiveUserId, requestUsername, receiveUsername));
+    }
+
+    @Transactional(readOnly = true)
+    public ContractResult getContract(UUID contractUuid) {
+        return contractRepository.findByUuid(contractUuid);
+    }
+
+    @Transactional(readOnly = true)
+    public DomainPage<ContractResult> getAllContracts(int page, int size, String sortBy) {
+        return contractRepository.findAll(sortBy, page, size);
+    }
+
+    @Transactional(readOnly = true)
+    public DomainPage<ContractResult> searchContracts(String username, int page, int size, String sortBy) {
+        return contractRepository.searchByUsername(username, sortBy, page, size);
+    }
+
+    @Transactional
+    public ContractResult acceptContract(UUID contractUuid) {
+        return contractRepository.acceptContract(contractUuid);
+    }
+
+    @Transactional
+    public ContractResult completeContract(UUID contractUuid, Long userId) {
+
+        ContractResult contract = contractRepository.findByUuid(contractUuid);
+
+        if (contract.getRequestUserId().equals(userId))
+            return contractRepository.requesterCompleteContract(contractUuid);
+
+        else if (contract.getReceiveUserId().equals(userId))
+            return contractRepository.receiverCompleteContract(contractUuid);
+
+        else
+            return null;
+    }
+
+    @Transactional
+    public ContractResult cancelContract(UUID contractUuid, Long userId) {
+        ContractResult contract = contractRepository.findByUuid(contractUuid);
+
+        if (contract.getRequestUserId().equals(userId))
+            return contractRepository.requesterCancelContract(contractUuid);
+
+        else if (contract.getReceiveUserId().equals(userId))
+            return contractRepository.receiverCancelContract(contractUuid);
+
+        else
+            return null;
+    }
+
+    @Transactional
+    public UUID deleteContract(UUID contractUuid) {
+        contractRepository.delete(contractUuid);
+
+        return contractUuid;
+    }
+
+}

--- a/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/custom/ContractRepositoryCustom.java
+++ b/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/custom/ContractRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.sheep.ezloan.contact.storage.custom;
+
+import com.sheep.ezloan.contact.storage.entity.ContractEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ContractRepositoryCustom {
+
+    Page<ContractEntity> searchByUsername(String username, Pageable pageable);
+
+}

--- a/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/entity/ContractEntity.java
+++ b/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/entity/ContractEntity.java
@@ -1,0 +1,119 @@
+package com.sheep.ezloan.contact.storage.entity;
+
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.contact.domain.model.ContractStatus;
+import com.sheep.ezloan.support.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+@Builder
+@Table(name = "p_contracts")
+public class ContractEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "contract_uuid")
+    private UUID contractUuid;
+
+    @Column(name = "post_uuid")
+    private UUID postUuid;
+
+    @Column(name = "request_user_id", nullable = false)
+    private Long requestUserId;
+
+    @Column(name = "receive_user_id", nullable = false)
+    private Long receiveUserId;
+
+    @Column(name = "request_username", nullable = false)
+    private String requestUsername;
+
+    @Column(name = "receive_username", nullable = false)
+    private String receiveUsername;
+
+    @Column(name = "is_accepted", nullable = false)
+    private Boolean isAccepted;
+
+    @Column(name = "requester_is_completed", nullable = false)
+    private Boolean requesterIsCompleted;
+
+    @Column(name = "receiver_is_completed", nullable = false)
+    private Boolean receiverIsCompleted;
+
+    @Column(name = "requester_is_canceled", nullable = false)
+    private Boolean requesterIsCanceled;
+
+    @Column(name = "receiver_is_canceled", nullable = false)
+    private Boolean receiverIsCanceled;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ContractStatus status;
+
+    public ContractEntity(UUID postUuid, Long requestUserId, Long receiveUserId, String requestUsername,
+            String receiveUsername) {
+        this.postUuid = postUuid;
+        this.requestUserId = requestUserId;
+        this.receiveUserId = receiveUserId;
+        this.requestUsername = requestUsername;
+        this.receiveUsername = receiveUsername;
+        this.isAccepted = false;
+        this.requesterIsCompleted = false;
+        this.receiverIsCompleted = false;
+        this.requesterIsCanceled = false;
+        this.receiverIsCanceled = false;
+        this.status = ContractStatus.WAITING;
+    }
+
+    public ContractResult toDomain() {
+        return ContractResult.builder()
+            .contractUuid(contractUuid)
+            .postUuid(postUuid)
+            .requestUserId(requestUserId)
+            .receiveUserId(receiveUserId)
+            .requestUsername(requestUsername)
+            .receiveUsername(receiveUsername)
+            .isAccepted(isAccepted)
+            .requesterIsCompleted(requesterIsCompleted)
+            .receiverIsCompleted(receiverIsCompleted)
+            .requesterIsCanceled(requesterIsCanceled)
+            .receiverIsCanceled(receiverIsCanceled)
+            .status(status)
+            .build();
+    }
+
+    public void accept() {
+        isAccepted = true;
+        status = ContractStatus.IN_PROGRESS;
+    }
+
+    public void requesterComplete() {
+        requesterIsCompleted = true;
+        if (receiverIsCompleted)
+            status = ContractStatus.COMPLETED;
+    }
+
+    public void receiverComplete() {
+        receiverIsCompleted = true;
+        if (requesterIsCompleted)
+            status = ContractStatus.COMPLETED;
+    }
+
+    public void requesterCancel() {
+        requesterIsCanceled = true;
+        if (receiverIsCanceled)
+            status = ContractStatus.CANCELED;
+    }
+
+    public void receiverCancel() {
+        receiverIsCanceled = true;
+        if (requesterIsCanceled)
+            status = ContractStatus.CANCELED;
+    }
+
+}

--- a/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/implement/ContractJpaRepository.java
+++ b/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/implement/ContractJpaRepository.java
@@ -1,0 +1,10 @@
+package com.sheep.ezloan.contact.storage.implement;
+
+import com.sheep.ezloan.contact.storage.entity.ContractEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ContractJpaRepository extends JpaRepository<ContractEntity, UUID> {
+
+}

--- a/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/implement/ContractRepositoryAdapter.java
+++ b/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/implement/ContractRepositoryAdapter.java
@@ -1,0 +1,112 @@
+package com.sheep.ezloan.contact.storage.implement;
+
+import com.sheep.ezloan.contact.domain.model.Contract;
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.contact.domain.repository.ContractRepository;
+import com.sheep.ezloan.contact.storage.custom.ContractRepositoryCustom;
+import com.sheep.ezloan.contact.storage.entity.ContractEntity;
+import com.sheep.ezloan.support.model.DomainPage;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ContractRepositoryAdapter implements ContractRepository {
+
+    private final ContractJpaRepository contractJpaRepository;
+
+    private final ContractRepositoryCustom contractRepositoryCustom;
+
+    @Override
+    public ContractResult save(Contract contract) {
+        ContractEntity contractEntity = new ContractEntity(contract.getPostUuid(), contract.getRequestUserId(),
+                contract.getReceiveUserId(), contract.getRequestUsername(), contract.getReceiveUsername());
+        return contractJpaRepository.save(contractEntity).toDomain();
+
+    }
+
+    @Override
+    public ContractResult findByUuid(UUID contractUuid) {
+        return contractJpaRepository.findById(contractUuid).orElseThrow(EntityNotFoundException::new).toDomain();
+    }
+
+    @Override
+    public DomainPage<ContractResult> findAll(String sortBy, int page, int size) {
+        Sort.Direction direction = Sort.Direction.ASC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Page<ContractResult> contractResultPage = contractJpaRepository.findAll(pageable).map(ContractEntity::toDomain);
+
+        return DomainPage.of(contractResultPage.getContent(), contractResultPage.getTotalElements(),
+                contractResultPage.getTotalPages(), contractResultPage.getNumber(), contractResultPage.getSize(),
+                contractResultPage.hasNext());
+    }
+
+    @Override
+    public DomainPage<ContractResult> searchByUsername(String username, String sortBy, int page, int size) {
+        Sort.Direction direction = Sort.Direction.ASC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Page<ContractResult> contractResultPage = contractRepositoryCustom.searchByUsername(username, pageable)
+            .map(ContractEntity::toDomain);
+
+        return DomainPage.of(contractResultPage.getContent(), contractResultPage.getTotalElements(),
+                contractResultPage.getTotalPages(), contractResultPage.getNumber(), contractResultPage.getSize(),
+                contractResultPage.hasNext());
+    }
+
+    @Override
+    public ContractResult acceptContract(UUID contractUuid) {
+        ContractEntity entity = contractJpaRepository.findById(contractUuid).orElseThrow(EntityNotFoundException::new);
+
+        entity.accept();
+        return contractJpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public ContractResult requesterCompleteContract(UUID contractUuid) {
+        ContractEntity entity = contractJpaRepository.findById(contractUuid).orElseThrow(EntityNotFoundException::new);
+
+        entity.requesterComplete();
+        return contractJpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public ContractResult receiverCompleteContract(UUID contractUuid) {
+        ContractEntity entity = contractJpaRepository.findById(contractUuid).orElseThrow(EntityNotFoundException::new);
+
+        entity.receiverComplete();
+        return contractJpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public ContractResult requesterCancelContract(UUID contractUuid) {
+        ContractEntity entity = contractJpaRepository.findById(contractUuid).orElseThrow(EntityNotFoundException::new);
+
+        entity.requesterCancel();
+        return contractJpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public ContractResult receiverCancelContract(UUID contractUuid) {
+        ContractEntity entity = contractJpaRepository.findById(contractUuid).orElseThrow(EntityNotFoundException::new);
+
+        entity.receiverCancel();
+        return contractJpaRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public void delete(UUID contractUuid) {
+        contractJpaRepository.deleteById(contractUuid);
+    }
+
+}

--- a/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/implement/ContractRepositoryImpl.java
+++ b/contact/contact-storage/src/main/java/com/sheep/ezloan/contact/storage/implement/ContractRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.sheep.ezloan.contact.storage.implement;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sheep.ezloan.contact.domain.model.ContractResult;
+import com.sheep.ezloan.contact.storage.custom.ContractRepositoryCustom;
+import com.sheep.ezloan.contact.storage.entity.ContractEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.sheep.ezloan.contact.storage.entity.QContractEntity.contractEntity;
+
+@Component
+@RequiredArgsConstructor
+public class ContractRepositoryImpl implements ContractRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ContractEntity> searchByUsername(String username, Pageable pageable) {
+        JPAQuery<ContractEntity> query = queryFactory.selectFrom(contractEntity)
+            .where(contractEntity.requestUsername.eq(username).or(contractEntity.receiveUsername.eq(username)));
+
+        List<ContractEntity> results = query.fetch();
+
+        return new PageImpl<>(results, pageable, results.size());
+    }
+
+}

--- a/support/support-api/src/main/java/com/sheep/ezloan/support/error/ErrorCode.java
+++ b/support/support-api/src/main/java/com/sheep/ezloan/support/error/ErrorCode.java
@@ -2,6 +2,6 @@ package com.sheep.ezloan.support.error;
 
 public enum ErrorCode {
 
-    E500
+    E500, E403
 
 }

--- a/support/support-api/src/main/java/com/sheep/ezloan/support/error/ErrorType.java
+++ b/support/support-api/src/main/java/com/sheep/ezloan/support/error/ErrorType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
-            LogLevel.ERROR);
+            LogLevel.ERROR),
+    FORBIDDEN(HttpStatus.FORBIDDEN, ErrorCode.E403, "접근 권한이 없습니다.", LogLevel.ERROR);
 
     private final HttpStatus status;
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #1 

## 📌 PR 요약

- Contract 도메인의 기본 CRUD + Search 기능을 구현하였습니다.
- 유저 권한에 따른 분기, 예외 처리 및 Post 도메인과의 연동, Contact App 전체의 Soft Delete와 같은 부분은 아직 구현되지 않았습니다.

## 🔍 주요 변경 사항

- Entity 작성
- Domain Model 생성
- Repository 생성
- Service 작성
- Dto 및 Controller 작성

## 🧪 테스트 방법

노션에 작성된 API 명세서를 참고하여 Postman을 이용한 통합 테스트를 진행할 수 있습니다.

## ✅ PR 체크리스트

- [x] 코드 컨벤션을 준수했나요?
- [x] 필요한 테스트를 추가하고 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요? (필요한 경우)

## 👀 리뷰어 체크 포인트

<!-- 리뷰어가 특별히 확인해야 할 부분이 있다면 언급해주세요 -->

## 💬 기타 코멘트

<!-- 추가로 공유할 내용이 있다면 여기에 적어주세요 -->